### PR TITLE
Fixed an issue where the filePath produces a nil URL

### DIFF
--- a/Sources/CrispView.swift
+++ b/Sources/CrispView.swift
@@ -74,9 +74,9 @@ open class CrispView: UIView, UIWebViewDelegate {
             filePath = frameworkBundle.path(forResource: "assets/index", ofType: "html")
         }
 
-        let urlPath =  URL(string: filePath!)
+        let urlPath =  URL(fileURLWithPath: filePath!)
 
-        webView.loadRequest(URLRequest(url: urlPath!))
+        webView.loadRequest(URLRequest(url: urlPath))
         
         if (Crisp.tokenId != nil && Crisp.tokenId != "") {
             CrispView.execute(script: "window.CRISP_TOKEN_ID = \"" + Crisp.tokenId + "\";");


### PR DESCRIPTION
This fix prevents the object `urlPath` assigned with a `nil` value.

Installed the library via Pods